### PR TITLE
Ensure swapfile is only readable for root

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adaptavist-swapfile'
-version '1.0.1'
+version '1.0.2'
 source 'https://github.com/Adaptavist/puppet-swapfile.git'
 author 'adaptavist'
 summary 'Puppet module for swap files' 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,12 @@ class swapfile(
             command => "/bin/dd if=/dev/zero of=${swapfile_path} bs=1M count=${swapfile_size}",
             creates => $swapfile_path,
         }
+        -> file { $swapfile_path:
+            ensure => 'file',
+            mode   => '0600',
+            owner  => 'root',
+            group  => 'root',
+        }
 
         exec { 'Attach swap file':
             command => "/sbin/mkswap ${swapfile_path} && /sbin/swapon ${swapfile_path}",

--- a/spec/classes/swapfile_spec.rb
+++ b/spec/classes/swapfile_spec.rb
@@ -23,6 +23,12 @@ describe 'swapfile', :type => 'class' do
             'require' => 'Exec[Create swap file]',
             'unless'  => "/sbin/swapon -s | grep #{swapfile_path}",
       )
+
+      should contain_file(swapfile_path).with(
+            'mode'  => '0600',
+            'owner' => 'root',
+            'group' => 'root',
+      )
     end
   end
 
@@ -51,6 +57,12 @@ describe 'swapfile', :type => 'class' do
       should contain_exec('Create swap file').with(
             'command'     => "/bin/dd if=/dev/zero of=#{cust_swapfile_path} bs=1M count=#{cust_swapfile_size}",
             'creates'     => cust_swapfile_path,
+      )
+
+      should contain_file(cust_swapfile_path).with(
+            'mode'  => '0600',
+            'owner' => 'root',
+            'group' => 'root',
       )
 
       should contain_exec('Attach swap file').with(


### PR DESCRIPTION
Swapfile should be root owned and readable to prevent other processes from reading potentially sensitive data.