### PR TITLE
Prevent swapfile from ending up in the file bucket

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adaptavist-swapfile'
-version '1.0.2'
+version '1.0.3'
 source 'https://github.com/Adaptavist/puppet-swapfile.git'
 author 'adaptavist'
 summary 'Puppet module for swap files' 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@ class swapfile(
             mode   => '0600',
             owner  => 'root',
             group  => 'root',
+            backup => false,
         }
 
         exec { 'Attach swap file':
@@ -79,6 +80,7 @@ class swapfile(
 
         file { $swapfile_path:
             ensure  => absent,
+            backup  => false,
             require => Exec['Detach swap file'],
         }
 

--- a/spec/classes/swapfile_spec.rb
+++ b/spec/classes/swapfile_spec.rb
@@ -42,6 +42,7 @@ describe 'swapfile', :type => 'class' do
 
       should contain_file(swapfile_path).with(
             'ensure'  => 'absent',
+            'backup'  => false,
             'require' => 'Exec[Detach swap file]',
       )
     end


### PR DESCRIPTION
When deleting files they get backed up in the filebucket, unless
globally disabled. Which is completely useless for swapfiles, it just
takes up a ton of space.

```
Info: /Stage[main]/Swapfile/File[/tmp/swap1]: Filebucketed /tmp/swap1 to puppet with sum cefc858a9feec6ff362f65588b8c8c5a
Notice: /Stage[main]/Swapfile/File[/tmp/swap1]/ensure: removed
```